### PR TITLE
[COR-242] fixed time conversions

### DIFF
--- a/timeutil/proto.go
+++ b/timeutil/proto.go
@@ -12,6 +12,11 @@ import (
 
 // TimeToTimestamp returns a protobuf Timestamp from a Time object
 func TimeToTimestamp(t time.Time) *timestamp.Timestamp {
+
+	if t.IsZero() {
+		return &timestamp.Timestamp{}
+	}
+
 	ts, err := ptypes.TimestampProto(t)
 	if nil != err {
 		log.Errorf("Time to Timestamp error: %s", err.Error())

--- a/timeutil/proto_test.go
+++ b/timeutil/proto_test.go
@@ -16,6 +16,11 @@ func TestTimeToTimestamp(t *testing.T) {
 	tm := time.Now()
 	ts := TimeToTimestamp(tm)
 	assert.Equal(tm.Unix(), ts.Seconds)
+
+	// test uninitialized time
+	tm = time.Time{}
+	ts = TimeToTimestamp(tm)
+	assert.Equal(int64(0), ts.Seconds)
 }
 
 func TestTimestampToTime(t *testing.T) {
@@ -28,6 +33,9 @@ func TestTimestampToTime(t *testing.T) {
 
 	tm = TimestampToTime(nil)
 	assert.True(tm.IsZero())
+
+	tm = TimestampToTime(&timestamp.Timestamp{})
+	assert.Equal(int64(0), tm.Unix())
 }
 
 func TestTimestampToNullTime(t *testing.T) {


### PR DESCRIPTION
The zero value for `time.Time` is year 1, and for `timestamp.Timestamp` is the year 1970. Using default conversion changes Unix time.

This PR fixes it - conversion back and forth should return the same Unix timestamp.

