### PR TITLE
[COR-1174] Add SSO as a common initialism for string casing utils

### DIFF
--- a/stringutil/snaker.go
+++ b/stringutil/snaker.go
@@ -179,6 +179,7 @@ var commonInitialisms = map[string]bool{
 	"SMTP":  true,
 	"SQL":   true,
 	"SSH":   true,
+	"SSO":   true,
 	"TCP":   true,
 	"TLS":   true,
 	"TTL":   true,


### PR DESCRIPTION
So we get SSOClient instead of SsoClient