### PR TITLE
[COR-1555] sqs: derive region from queue URL in NewFromURL

### DIFF
--- a/messagequeue/sqs/client.go
+++ b/messagequeue/sqs/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/beaconsoftwarellc/gadget/v2/errors"
 	"github.com/beaconsoftwarellc/gadget/v2/log"
 	"github.com/beaconsoftwarellc/gadget/v2/messagequeue"
 	"github.com/beaconsoftwarellc/gadget/v2/stringutil"
@@ -48,27 +49,35 @@ func New(region string, queueLocator *url.URL) messagequeue.MessageQueue {
 	}
 }
 
-// NewFromURL returns an SQS instance located at queueLocator with the AWS
+// NewFromURL returns a [messagequeue.MessageQueue] instance located at 'queueLocator' with the AWS
 // region derived from the queue URL. Standard SQS URLs of the form
-// https://sqs.{region}.amazonaws.com/... yield {region}; non-standard URLs
-// (e.g. LocalStack) yield an empty region so the SDK falls back to its
-// default credential-chain region.
-func NewFromURL(queueLocator *url.URL) messagequeue.MessageQueue {
-	return New(RegionFromURL(queueLocator), queueLocator)
+// https://sqs.{region}.amazonaws.com/... yield {region}; URLs whose host
+// is 'localhost' yield [LocalRegion] for local testing against an
+// elasticmq/LocalStack instance.
+func NewFromURL(queueLocator *url.URL) (messagequeue.MessageQueue, error) {
+	region, err := RegionFromURL(queueLocator)
+	if err != nil {
+		return nil, err
+	}
+	return New(region, queueLocator), nil
 }
 
 // RegionFromURL parses the AWS region from a standard SQS queue URL
-// (https://sqs.{region}.amazonaws.com/...). Returns empty string for
-// non-standard URLs.
-func RegionFromURL(queueLocator *url.URL) string {
+// (https://sqs.{region}.amazonaws.com/...). For URLs whose host is
+// 'localhost' it returns [LocalRegion].
+func RegionFromURL(queueLocator *url.URL) (string, error) {
 	if queueLocator == nil {
-		return ""
+		return "", errors.New("queueLocator cannot be nil")
 	}
-	parts := strings.SplitN(queueLocator.Hostname(), ".", 4)
+	host := queueLocator.Hostname()
+	if host == "localhost" {
+		return LocalRegion, nil
+	}
+	parts := strings.SplitN(host, ".", 4)
 	if len(parts) >= 4 && parts[0] == "sqs" && parts[2] == "amazonaws" {
-		return parts[1]
+		return parts[1], nil
 	}
-	return ""
+	return "", errors.Newf("unrecognized SQS queue URL host: %q", host)
 }
 
 type sdk struct {

--- a/messagequeue/sqs/client.go
+++ b/messagequeue/sqs/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -45,6 +46,29 @@ func New(region string, queueLocator *url.URL) messagequeue.MessageQueue {
 		region:   region,
 		queueUrl: queueLocator,
 	}
+}
+
+// NewFromURL returns an SQS instance located at queueLocator with the AWS
+// region derived from the queue URL. Standard SQS URLs of the form
+// https://sqs.{region}.amazonaws.com/... yield {region}; non-standard URLs
+// (e.g. LocalStack) yield an empty region so the SDK falls back to its
+// default credential-chain region.
+func NewFromURL(queueLocator *url.URL) messagequeue.MessageQueue {
+	return New(RegionFromURL(queueLocator), queueLocator)
+}
+
+// RegionFromURL parses the AWS region from a standard SQS queue URL
+// (https://sqs.{region}.amazonaws.com/...). Returns empty string for
+// non-standard URLs.
+func RegionFromURL(queueLocator *url.URL) string {
+	if queueLocator == nil {
+		return ""
+	}
+	parts := strings.SplitN(queueLocator.Hostname(), ".", 4)
+	if len(parts) >= 4 && parts[0] == "sqs" && parts[2] == "amazonaws" {
+		return parts[1]
+	}
+	return ""
 }
 
 type sdk struct {

--- a/messagequeue/sqs/client.go
+++ b/messagequeue/sqs/client.go
@@ -38,6 +38,10 @@ const (
 	// LocalRegion is for testing locally with a docker instance running elasticmq
 	LocalRegion = "local"
 
+	// localhostHost is the hostname used to identify a local SQS endpoint
+	// (e.g. elasticmq or LocalStack) when parsing a queue URL.
+	localhostHost = "localhost"
+
 	unknownErrorMessage = "unknown error occurred"
 )
 
@@ -70,7 +74,7 @@ func RegionFromURL(queueLocator *url.URL) (string, error) {
 		return "", errors.New("queueLocator cannot be nil")
 	}
 	host := queueLocator.Hostname()
-	if host == "localhost" {
+	if host == localhostHost {
 		return LocalRegion, nil
 	}
 	parts := strings.SplitN(host, ".", 4)

--- a/messagequeue/sqs/client_test.go
+++ b/messagequeue/sqs/client_test.go
@@ -143,9 +143,10 @@ func initialize(t *testing.T) (context.Context, *assert.Assertions, *MockAPI, *s
 func Test_SQS_RegionFromURL(t *testing.T) {
 	assert := assert.New(t)
 	tests := []struct {
-		name     string
-		raw      string
-		expected string
+		name        string
+		raw         string
+		expected    string
+		expectError bool
 	}{
 		{
 			name:     "standard SQS URL",
@@ -158,40 +159,71 @@ func Test_SQS_RegionFromURL(t *testing.T) {
 			expected: "eu-west-2",
 		},
 		{
-			name:     "LocalStack-style URL",
+			name:     "localhost URL maps to LocalRegion",
 			raw:      "http://localhost:4566/000000000000/queue",
-			expected: "",
+			expected: LocalRegion,
 		},
 		{
-			name:     "non-amazonaws host",
-			raw:      "https://sqs.us-east-1.example.com/queue",
-			expected: "",
+			name:        "non-amazonaws host",
+			raw:         "https://sqs.us-east-1.example.com/queue",
+			expectError: true,
 		},
 		{
-			name:     "missing sqs prefix",
-			raw:      "https://us-east-1.amazonaws.com/queue",
-			expected: "",
+			name:        "missing sqs prefix",
+			raw:         "https://us-east-1.amazonaws.com/queue",
+			expectError: true,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			parsed, err := url.Parse(tc.raw)
 			assert.NoError(err)
-			assert.Equal(tc.expected, RegionFromURL(parsed))
+			region, err := RegionFromURL(parsed)
+			if tc.expectError {
+				assert.Error(err)
+				assert.Equal("", region)
+			} else {
+				assert.NoError(err)
+				assert.Equal(tc.expected, region)
+			}
 		})
 	}
-	assert.Equal("", RegionFromURL(nil))
+	region, err := RegionFromURL(nil)
+	assert.Error(err)
+	assert.Equal("", region)
 }
 
 func Test_SQS_NewFromURL(t *testing.T) {
 	assert := assert.New(t)
 	parsed, err := url.Parse("https://sqs.us-east-1.amazonaws.com/123456789012/queue")
 	assert.NoError(err)
-	mq := NewFromURL(parsed)
+	mq, err := NewFromURL(parsed)
+	assert.NoError(err)
 	sdk, ok := mq.(*sdk)
 	assert.True(ok)
 	assert.Equal("us-east-1", sdk.region)
 	assert.Equal(parsed, sdk.queueUrl)
+}
+
+func Test_SQS_NewFromURL_Localhost(t *testing.T) {
+	assert := assert.New(t)
+	parsed, err := url.Parse("http://localhost:4566/000000000000/queue")
+	assert.NoError(err)
+	mq, err := NewFromURL(parsed)
+	assert.NoError(err)
+	sdk, ok := mq.(*sdk)
+	assert.True(ok)
+	assert.Equal(LocalRegion, sdk.region)
+	assert.Equal(parsed, sdk.queueUrl)
+}
+
+func Test_SQS_NewFromURL_Error(t *testing.T) {
+	assert := assert.New(t)
+	parsed, err := url.Parse("https://sqs.us-east-1.example.com/queue")
+	assert.NoError(err)
+	mq, err := NewFromURL(parsed)
+	assert.Error(err)
+	assert.Nil(mq)
 }
 
 func Test_SQS_EnqueueBatch(t *testing.T) {

--- a/messagequeue/sqs/client_test.go
+++ b/messagequeue/sqs/client_test.go
@@ -140,6 +140,60 @@ func initialize(t *testing.T) (context.Context, *assert.Assertions, *MockAPI, *s
 	return context, assert, apiMock, sdk
 }
 
+func Test_SQS_RegionFromURL(t *testing.T) {
+	assert := assert.New(t)
+	tests := []struct {
+		name     string
+		raw      string
+		expected string
+	}{
+		{
+			name:     "standard SQS URL",
+			raw:      "https://sqs.us-east-1.amazonaws.com/123456789012/queue",
+			expected: "us-east-1",
+		},
+		{
+			name:     "standard SQS URL with different region",
+			raw:      "https://sqs.eu-west-2.amazonaws.com/123456789012/queue",
+			expected: "eu-west-2",
+		},
+		{
+			name:     "LocalStack-style URL",
+			raw:      "http://localhost:4566/000000000000/queue",
+			expected: "",
+		},
+		{
+			name:     "non-amazonaws host",
+			raw:      "https://sqs.us-east-1.example.com/queue",
+			expected: "",
+		},
+		{
+			name:     "missing sqs prefix",
+			raw:      "https://us-east-1.amazonaws.com/queue",
+			expected: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := url.Parse(tc.raw)
+			assert.NoError(err)
+			assert.Equal(tc.expected, RegionFromURL(parsed))
+		})
+	}
+	assert.Equal("", RegionFromURL(nil))
+}
+
+func Test_SQS_NewFromURL(t *testing.T) {
+	assert := assert.New(t)
+	parsed, err := url.Parse("https://sqs.us-east-1.amazonaws.com/123456789012/queue")
+	assert.NoError(err)
+	mq := NewFromURL(parsed)
+	sdk, ok := mq.(*sdk)
+	assert.True(ok)
+	assert.Equal("us-east-1", sdk.region)
+	assert.Equal(parsed, sdk.queueUrl)
+}
+
 func Test_SQS_EnqueueBatch(t *testing.T) {
 	ctx, assert, apiMock, sdk := initialize(t)
 	message := &messagequeue.Message{}


### PR DESCRIPTION
## Summary
- Add `sqs.NewFromURL(queueLocator)` that constructs the SQS message queue with the AWS region derived from the queue URL — eliminating the redundant region argument at call sites that already have a standard SQS queue URL in hand.
- Expose `sqs.RegionFromURL(queueLocator)` as a small helper that parses the region from `https://sqs.{region}.amazonaws.com/...` hosts and returns an empty string for non-standard URLs (e.g. LocalStack), so the SDK falls back to its default credential-chain region.
- Existing `sqs.New(region, queueLocator)` is left untouched so callers that need to pass an explicit region (e.g. configured override) continue to work without changes.

This is requested by code review on ecatholic/core#COR-1555 (cron SQS execution): the cron service derives the region from the queue URL itself, so the previous `sqs.New(sqsRegion(queueLocator), queueLocator)` call site is redundant. Pushing the derivation down into the gadget package lets that call site become `sqs.NewFromURL(queueLocator)` and keeps the parser in one place for any future caller with the same shape.
