### PR TITLE
[PAY-776] qb: math operators take SelectExpression, optional alias

### DIFF
--- a/database/qb/math.go
+++ b/database/qb/math.go
@@ -3,6 +3,8 @@ package qb
 import (
 	"fmt"
 	"strings"
+
+	"github.com/beaconsoftwarellc/gadget/v2/stringutil"
 )
 
 type mathOperator string
@@ -15,9 +17,9 @@ const (
 )
 
 type math struct {
-	fields   []TableField
-	operator mathOperator
-	alias    string
+	expressions []SelectExpression
+	operator    mathOperator
+	alias       string
 }
 
 func (a math) GetName() string {
@@ -26,36 +28,51 @@ func (a math) GetName() string {
 
 func (a math) GetTables() []string {
 	tables := make([]string, 0)
-	for _, field := range a.fields {
-		tables = append(tables, field.GetTables()...)
+	for _, expression := range a.expressions {
+		tables = append(tables, expression.GetTables()...)
 	}
 	return tables
 }
 
 func (a math) ParameterizedSQL() (string, []any) {
-	fields := make([]string, 0)
-	for _, field := range a.fields {
-		fields = append(fields, field.SQL())
+	parts := make([]string, len(a.expressions))
+	values := []any{}
+	for i, expression := range a.expressions {
+		sql, expValues := expression.ParameterizedSQL()
+		parts[i] = sql
+		values = append(values, expValues...)
 	}
-	return fmt.Sprintf("%s AS `%s`", strings.Join(fields, string(a.operator)), a.alias), nil
+	sql := strings.Join(parts, string(a.operator))
+	if !stringutil.IsWhiteSpace(a.alias) {
+		sql = fmt.Sprintf("%s AS `%s`", sql, a.alias)
+	}
+	return sql, values
 }
 
-// Add the 2 fields together
-func Add(tableFields []TableField, aliasName string) SelectExpression {
-	return math{fields: tableFields, alias: aliasName, operator: add}
+// Add the passed expressions together. Pass an empty aliasName to embed the
+// result inside another SelectExpression (e.g. Sum), or a non-empty aliasName
+// when using as a top-level column.
+func Add(expressions []SelectExpression, aliasName string) SelectExpression {
+	return math{expressions: expressions, alias: aliasName, operator: add}
 }
 
-// Subtract the 2 fields together
-func Subtract(tableFields []TableField, aliasName string) SelectExpression {
-	return math{fields: tableFields, alias: aliasName, operator: subtract}
+// Subtract the passed expressions. Pass an empty aliasName to embed the result
+// inside another SelectExpression (e.g. Sum), or a non-empty aliasName when
+// using as a top-level column.
+func Subtract(expressions []SelectExpression, aliasName string) SelectExpression {
+	return math{expressions: expressions, alias: aliasName, operator: subtract}
 }
 
-// Multiply the 2 fields together
-func Multiply(tableFields []TableField, aliasName string) SelectExpression {
-	return math{fields: tableFields, alias: aliasName, operator: multiply}
+// Multiply the passed expressions together. Pass an empty aliasName to embed
+// the result inside another SelectExpression (e.g. Sum), or a non-empty
+// aliasName when using as a top-level column.
+func Multiply(expressions []SelectExpression, aliasName string) SelectExpression {
+	return math{expressions: expressions, alias: aliasName, operator: multiply}
 }
 
-// Divide the 2 fields together
-func Divide(tableFields []TableField, aliasName string) SelectExpression {
-	return math{fields: tableFields, alias: aliasName, operator: divide}
+// Divide the passed expressions. Pass an empty aliasName to embed the result
+// inside another SelectExpression (e.g. Sum), or a non-empty aliasName when
+// using as a top-level column.
+func Divide(expressions []SelectExpression, aliasName string) SelectExpression {
+	return math{expressions: expressions, alias: aliasName, operator: divide}
 }

--- a/database/qb/math_test.go
+++ b/database/qb/math_test.go
@@ -13,14 +13,14 @@ func Test_NewAdd(t *testing.T) {
 	expectedField2 := TableField{Name: generator.String(20), Table: generator.String(20)}
 	expectedAlias := generator.String(20)
 
-	expression := Add([]TableField{expectedField1, expectedField2}, expectedAlias)
+	expression := Add([]SelectExpression{expectedField1, expectedField2}, expectedAlias)
 
 	assert.Equal(t, expectedAlias, expression.GetName())
 	assert.Contains(t, expression.GetTables(), expectedField1.Table)
 	assert.Contains(t, expression.GetTables(), expectedField2.Table)
 	actualSql, actualParams := expression.ParameterizedSQL()
 	assert.Equal(t, fmt.Sprintf("%s + %s AS `%s`", expectedField1.SQL(), expectedField2.SQL(), expectedAlias), actualSql)
-	assert.Nil(t, actualParams)
+	assert.Empty(t, actualParams)
 }
 
 func Test_NewSubtract(t *testing.T) {
@@ -28,14 +28,14 @@ func Test_NewSubtract(t *testing.T) {
 	expectedField2 := TableField{Name: generator.String(20), Table: generator.String(20)}
 	expectedAlias := generator.String(20)
 
-	expression := Subtract([]TableField{expectedField1, expectedField2}, expectedAlias)
+	expression := Subtract([]SelectExpression{expectedField1, expectedField2}, expectedAlias)
 
 	assert.Equal(t, expectedAlias, expression.GetName())
 	assert.Contains(t, expression.GetTables(), expectedField1.Table)
 	assert.Contains(t, expression.GetTables(), expectedField2.Table)
 	actualSql, actualParams := expression.ParameterizedSQL()
 	assert.Equal(t, fmt.Sprintf("%s - %s AS `%s`", expectedField1.SQL(), expectedField2.SQL(), expectedAlias), actualSql)
-	assert.Nil(t, actualParams)
+	assert.Empty(t, actualParams)
 }
 
 func Test_NewDivide(t *testing.T) {
@@ -43,14 +43,14 @@ func Test_NewDivide(t *testing.T) {
 	expectedField2 := TableField{Name: generator.String(20), Table: generator.String(20)}
 	expectedAlias := generator.String(20)
 
-	expression := Divide([]TableField{expectedField1, expectedField2}, expectedAlias)
+	expression := Divide([]SelectExpression{expectedField1, expectedField2}, expectedAlias)
 
 	assert.Equal(t, expectedAlias, expression.GetName())
 	assert.Contains(t, expression.GetTables(), expectedField1.Table)
 	assert.Contains(t, expression.GetTables(), expectedField2.Table)
 	actualSql, actualParams := expression.ParameterizedSQL()
 	assert.Equal(t, fmt.Sprintf("%s / %s AS `%s`", expectedField1.SQL(), expectedField2.SQL(), expectedAlias), actualSql)
-	assert.Nil(t, actualParams)
+	assert.Empty(t, actualParams)
 }
 
 func Test_NewMultiply(t *testing.T) {
@@ -58,12 +58,36 @@ func Test_NewMultiply(t *testing.T) {
 	expectedField2 := TableField{Name: generator.String(20), Table: generator.String(20)}
 	expectedAlias := generator.String(20)
 
-	expression := Multiply([]TableField{expectedField1, expectedField2}, expectedAlias)
+	expression := Multiply([]SelectExpression{expectedField1, expectedField2}, expectedAlias)
 
 	assert.Equal(t, expectedAlias, expression.GetName())
 	assert.Contains(t, expression.GetTables(), expectedField1.Table)
 	assert.Contains(t, expression.GetTables(), expectedField2.Table)
 	actualSql, actualParams := expression.ParameterizedSQL()
 	assert.Equal(t, fmt.Sprintf("%s * %s AS `%s`", expectedField1.SQL(), expectedField2.SQL(), expectedAlias), actualSql)
-	assert.Nil(t, actualParams)
+	assert.Empty(t, actualParams)
+}
+
+func Test_Multiply_EmptyAliasOmitsAsClause(t *testing.T) {
+	expectedField1 := TableField{Name: generator.String(20), Table: generator.String(20)}
+	expectedField2 := TableField{Name: generator.String(20), Table: generator.String(20)}
+
+	expression := Multiply([]SelectExpression{expectedField1, expectedField2}, "")
+
+	assert.Empty(t, expression.GetName())
+	actualSql, actualParams := expression.ParameterizedSQL()
+	assert.Equal(t, fmt.Sprintf("%s * %s", expectedField1.SQL(), expectedField2.SQL()), actualSql)
+	assert.Empty(t, actualParams)
+}
+
+func Test_Multiply_ComposesInsideSum(t *testing.T) {
+	expectedField1 := TableField{Name: generator.String(20), Table: generator.String(20)}
+	expectedField2 := TableField{Name: generator.String(20), Table: generator.String(20)}
+	expectedAlias := generator.String(20)
+
+	expression := Sum(Multiply([]SelectExpression{expectedField1, expectedField2}, ""), expectedAlias)
+
+	actualSql, actualParams := expression.ParameterizedSQL()
+	assert.Equal(t, fmt.Sprintf("SUM(%s * %s) AS `%s`", expectedField1.SQL(), expectedField2.SQL(), expectedAlias), actualSql)
+	assert.Empty(t, actualParams)
 }


### PR DESCRIPTION
## Summary

Change `Add`/`Subtract`/`Multiply`/`Divide` in `database/qb/math.go` to:

- accept `[]SelectExpression` instead of `[]TableField`, and
- skip the trailing `` AS `alias` `` when `aliasName` is empty (matching the pattern already used by `Sum`/`Coalesce`).

This lets math expressions compose inside aggregates:

```go
qb.Sum(qb.Multiply([]qb.SelectExpression{Quantity, Amount}, ""), "alias")
// -> SUM(`scheduled_order_item`.`quantity` * `product_price`.`amount`) AS `alias`
```

Without this change, the inner `Multiply` always emitted `AS alias`, which produced invalid SQL inside `SUM(...)`. Motivated by the review on ecatholic/penny#545 (`ScheduledOrderMeta.Amount` SUM expression).
