### PR TITLE
[PAY-776] qb: If takes SelectExpression values, optional alias

### DIFF
--- a/database/qb/querybuilder_test.go
+++ b/database/qb/querybuilder_test.go
@@ -390,27 +390,22 @@ func TestQueryBuilderCoalesce(t *testing.T) {
 
 func TestQueryBuilderIfFieldCondition(t *testing.T) {
 	assert := assert1.New(t)
-	require := require.New(t)
-	query := Select(Person.ID, If(Person.Name.Equal(Person.ID), "1", "0", "has_robot_name")).From(Person)
+	query := Select(Person.ID, If(Person.Name.Equal(Person.ID), Person.Name, Person.AddressID, "robot_name")).From(Person)
 	actual, values, err := query.SQL(NewLimitOffset[int]().SetLimit(NoLimit).SetOffset(10))
 	assert.NoError(err)
-	require.Len(values, 2)
-	assert.Equal("1", values[0])
-	assert.Equal("0", values[1])
-	assert.Equal("SELECT `person`.`id`, IF(`person`.`name` = `person`.`id`, ?, ?) AS `has_robot_name` FROM `person` AS `person` OFFSET 10", actual)
+	assert.Empty(values)
+	assert.Equal("SELECT `person`.`id`, IF(`person`.`name` = `person`.`id`, `person`.`name`, `person`.`address_id`) AS `robot_name` FROM `person` AS `person` OFFSET 10", actual)
 }
 
 func TestQueryBuilderIfStringCondition(t *testing.T) {
 	assert := assert1.New(t)
 	require := require.New(t)
-	query := Select(Person.ID, If(Person.Name.Equal("Joe"), "1", "0", "is_joe")).From(Person)
+	query := Select(Person.ID, If(Person.Name.Equal("Joe"), Person.Name, Person.AddressID, "joe_name")).From(Person)
 	actual, values, err := query.SQL(NewLimitOffset[int]().SetLimit(NoLimit).SetOffset(10))
 	assert.NoError(err)
-	require.Len(values, 3)
+	require.Len(values, 1)
 	assert.Equal("Joe", values[0])
-	assert.Equal("1", values[1])
-	assert.Equal("0", values[2])
-	assert.Equal("SELECT `person`.`id`, IF(`person`.`name` = ?, ?, ?) AS `is_joe` FROM `person` AS `person` OFFSET 10", actual)
+	assert.Equal("SELECT `person`.`id`, IF(`person`.`name` = ?, `person`.`name`, `person`.`address_id`) AS `joe_name` FROM `person` AS `person` OFFSET 10", actual)
 }
 
 func TestQueryBuilderGroupBy(t *testing.T) {

--- a/database/qb/select.go
+++ b/database/qb/select.go
@@ -43,8 +43,8 @@ func Alias(tableField TableField, aliasName string) SelectExpression {
 // IF (condition, true, false) AS alias
 type ifStatement struct {
 	condition  *ConditionExpression
-	trueValue  string
-	falseValue string
+	trueValue  SelectExpression
+	falseValue SelectExpression
 	alias      string
 }
 
@@ -53,16 +53,29 @@ func (i ifStatement) GetName() string {
 }
 
 func (i ifStatement) GetTables() []string {
-	return i.condition.Tables()
+	tables := i.condition.Tables()
+	tables = append(tables, i.trueValue.GetTables()...)
+	tables = append(tables, i.falseValue.GetTables()...)
+	return tables
 }
 
 func (i ifStatement) ParameterizedSQL() (string, []any) {
 	conditionSQL, values := i.condition.SQL()
-	return fmt.Sprintf("IF(%s, ?, ?) AS `%s`", conditionSQL, i.alias), append(values, i.trueValue, i.falseValue)
+	trueSQL, trueValues := i.trueValue.ParameterizedSQL()
+	falseSQL, falseValues := i.falseValue.ParameterizedSQL()
+	values = append(values, trueValues...)
+	values = append(values, falseValues...)
+	sql := fmt.Sprintf("IF(%s, %s, %s)", conditionSQL, trueSQL, falseSQL)
+	if !stringutil.IsWhiteSpace(i.alias) {
+		sql += fmt.Sprintf(" AS `%s`", i.alias)
+	}
+	return sql, values
 }
 
-// If creates a SQL IF statement that can be used as a SelectExpression
-func If(condition *ConditionExpression, trueValue, falseValue, alias string) SelectExpression {
+// If creates a SQL IF statement that can be used as a [SelectExpression]. Pass
+// an empty alias to embed the result inside another [SelectExpression] (e.g.
+// [Sum]), or a non-empty alias when using as a top-level column.
+func If(condition *ConditionExpression, trueValue, falseValue SelectExpression, alias string) SelectExpression {
 	return ifStatement{condition: condition, trueValue: trueValue, falseValue: falseValue, alias: alias}
 }
 

--- a/database/qb/select_test.go
+++ b/database/qb/select_test.go
@@ -1,0 +1,79 @@
+package qb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/beaconsoftwarellc/gadget/v2/generator"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewIf(t *testing.T) {
+	conditionField := TableField{Name: generator.String(20), Table: generator.String(20)}
+	expectedConditionValue := generator.String(20)
+	trueField := TableField{Name: generator.String(20), Table: generator.String(20)}
+	falseField := TableField{Name: generator.String(20), Table: generator.String(20)}
+	expectedAlias := generator.String(20)
+
+	condition := conditionField.Equal(expectedConditionValue)
+	expression := If(condition, trueField, falseField, expectedAlias)
+
+	assert.Equal(t, expectedAlias, expression.GetName())
+	conditionSQL, conditionValues := condition.SQL()
+	actualSQL, actualParams := expression.ParameterizedSQL()
+	assert.Equal(t,
+		fmt.Sprintf("IF(%s, %s, %s) AS `%s`", conditionSQL, trueField.SQL(), falseField.SQL(), expectedAlias),
+		actualSQL,
+	)
+	assert.Equal(t, conditionValues, actualParams)
+}
+
+func Test_If_EmptyAliasOmitsAsClause(t *testing.T) {
+	conditionField := TableField{Name: generator.String(20), Table: generator.String(20)}
+	trueField := TableField{Name: generator.String(20), Table: generator.String(20)}
+	falseField := TableField{Name: generator.String(20), Table: generator.String(20)}
+
+	condition := conditionField.Equal(generator.String(20))
+	expression := If(condition, trueField, falseField, "")
+
+	assert.Empty(t, expression.GetName())
+	conditionSQL, conditionValues := condition.SQL()
+	actualSQL, actualParams := expression.ParameterizedSQL()
+	assert.Equal(t,
+		fmt.Sprintf("IF(%s, %s, %s)", conditionSQL, trueField.SQL(), falseField.SQL()),
+		actualSQL,
+	)
+	assert.Equal(t, conditionValues, actualParams)
+}
+
+func Test_If_GetTablesUnionsAllBranches(t *testing.T) {
+	conditionField := TableField{Name: generator.String(20), Table: generator.String(20)}
+	trueField := TableField{Name: generator.String(20), Table: generator.String(20)}
+	falseField := TableField{Name: generator.String(20), Table: generator.String(20)}
+
+	condition := conditionField.Equal(generator.String(20))
+	expression := If(condition, trueField, falseField, generator.String(20))
+
+	tables := expression.GetTables()
+	assert.Contains(t, tables, conditionField.Table)
+	assert.Contains(t, tables, trueField.Table)
+	assert.Contains(t, tables, falseField.Table)
+}
+
+func Test_If_ComposesInsideSum(t *testing.T) {
+	conditionField := TableField{Name: generator.String(20), Table: generator.String(20)}
+	trueField := TableField{Name: generator.String(20), Table: generator.String(20)}
+	falseField := TableField{Name: generator.String(20), Table: generator.String(20)}
+	expectedAlias := generator.String(20)
+
+	condition := conditionField.Equal(generator.String(20))
+	expression := Sum(If(condition, trueField, falseField, ""), expectedAlias)
+
+	conditionSQL, conditionValues := condition.SQL()
+	actualSQL, actualParams := expression.ParameterizedSQL()
+	assert.Equal(t,
+		fmt.Sprintf("SUM(IF(%s, %s, %s)) AS `%s`", conditionSQL, trueField.SQL(), falseField.SQL(), expectedAlias),
+		actualSQL,
+	)
+	assert.Equal(t, conditionValues, actualParams)
+}


### PR DESCRIPTION
## Summary

Make `qb.If` accept `SelectExpression` for its true and false branches instead of plain `string` values, and skip the trailing `AS alias` when alias is empty (matching `Sum`, `Coalesce`, and the math operators changed in 4166371). Branch SQL is inlined via `ParameterizedSQL`, and `GetTables` now unions the condition tables with the tables from both branches so the query validator sees joins required by either branch.

This lets callers write things like:

```go
qb.If(meta.ScheduledOrderItem.AmountOverride.GreaterThan(0),
    meta.ScheduledOrderItem.AmountOverride, // true
    meta.ProductPrice.Amount,               // false
    meta.ScheduledOrderMeta.Amount.Name,    // alias
)
```
